### PR TITLE
Disabled SelfTests on philsquared/Catch.

### DIFF
--- a/recipes/philsquared/catch/package.txt
+++ b/recipes/philsquared/catch/package.txt
@@ -1,1 +1,2 @@
-philsquared/Catch@master
+philsquared/Catch@master -DNO_SELFTEST=1
+


### PR DESCRIPTION
Improves compiler compatibility (especially on old versions of OSX).
(The project devs suggested the SelfTests are only really intended for their own use anyway.)