### PR TITLE
Fix recipe for google/benchmark

### DIFF
--- a/recipes/google/benchmark/package.txt
+++ b/recipes/google/benchmark/package.txt
@@ -1,1 +1,1 @@
-google/benchmark@master
+google/benchmark@master -DBENCHMARK_ENABLE_GTEST_TESTS=OFF


### PR DESCRIPTION
Fix the recipe for google/benchmark. It fails to find googletest, so this disables the use of googletest. Fortunately, there are a bunch of non-googletest tests as well, so we can still verify that the benchmark library is working properly. Also see issue #23 for more discussion of this.