### PR TITLE
Add dummy google/benchmark/requirements.txt

### DIFF
--- a/recipes/google/benchmark/requirements.txt
+++ b/recipes/google/benchmark/requirements.txt
@@ -1,0 +1,3 @@
+# This dummy requirements.txt file is here only to suppress the use of
+# the (non-cget-related) requirements.txt file found in the Google
+# Benchmark source.


### PR DESCRIPTION
Google benchmark has a requirement.txt file in the top-level
directory, but this file is unrelated to cget. It causes cget builds
to fail because the requirements.txt file format doesn't match what
cget expected. Putting a dummy requirements.txt in this cget recipe
works around the issue.